### PR TITLE
feat(lsp): add configurations for clangd, luals, and ruby_lsp

### DIFF
--- a/alias.sh
+++ b/alias.sh
@@ -5,7 +5,6 @@ alias cup="tmux new -s tmux_up"
 alias up="tmux attach -d -t tmux_up; clear"
 
 alias gl="git log --graph --oneline --decorate --all"
-alias gc="git commit -v"  # verbose commit (you can also configure this git config --global commit.verbose true)
 
 alias e=neovide
 

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,3 +1,4 @@
 require('config.lazy')
 require('config.remaps')
 require('config.general')
+require('config.lsp')

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -6,7 +6,9 @@
   "copilot.vim": { "branch": "release", "commit": "a9228e015528c9307890c48083c925eb98a64a79" },
   "cyberdream.nvim": { "branch": "main", "commit": "f36d7991b6373ebda9cfca20030aa1fca7328ea8" },
   "dracula.nvim": { "branch": "main", "commit": "96c9d19ce81b26053055ad6f688277d655b3f7d2" },
+  "git-blame.nvim": { "branch": "master", "commit": "b12da2156ec1c3f53f42c129201ff0bfed69c86e" },
   "github-nvim-theme": { "branch": "main", "commit": "c106c9472154d6b2c74b74565616b877ae8ed31d" },
+  "gitlinker.nvim": { "branch": "master", "commit": "cc59f732f3d043b626c8702cb725c82e54d35c25" },
   "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },
   "lualine.nvim": { "branch": "master", "commit": "1517caa8fff05e4b4999857319d3b0609a7f57fa" },
   "molokai": { "branch": "master", "commit": "c67bdfcdb31415aa0ade7f8c003261700a885476" },
@@ -27,6 +29,8 @@
   "telescope.nvim": { "branch": "master", "commit": "a4ed82509cecc56df1c7138920a1aeaf246c0ac5" },
   "toggleterm.nvim": { "branch": "main", "commit": "50ea089fc548917cc3cc16b46a8211833b9e3c7c" },
   "tokyodark.nvim": { "branch": "master", "commit": "cc70a2fb809d5376f2bd8e5836f9bb3f5fb8ef43" },
+  "vim-fugitive": { "branch": "master", "commit": "4a745ea72fa93bb15dd077109afbb3d1809383f2" },
+  "vim-gitgutter": { "branch": "main", "commit": "6620e5fbbe6a28de0bfed081f5bd2767023b7eea" },
   "vim-github-colorscheme": { "branch": "master", "commit": "0a660059cae852c7f90951dea7474cfb1485558e" },
   "vim-moonfly-colors": { "branch": "master", "commit": "77f9b30584547de15b9c1c30247945c19c1243bf" }
 }

--- a/nvim/lsp/clangd.lua
+++ b/nvim/lsp/clangd.lua
@@ -1,0 +1,5 @@
+return {
+  cmd = { 'clangd' },
+  root_markers = { '.clangd', 'compile_commands.json' },
+  filetypes = { 'c', 'cpp' },
+}

--- a/nvim/lsp/luals.lua
+++ b/nvim/lsp/luals.lua
@@ -1,0 +1,5 @@
+return {
+  cmd = { 'lua-language-server' },
+  root_markers = { '.luarc.json', '.luarc.jsonc', '.git' },
+  filetypes = { 'lua' },
+}

--- a/nvim/lsp/ruby_lsp.lua
+++ b/nvim/lsp/ruby_lsp.lua
@@ -1,0 +1,13 @@
+return {
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        ruby_lsp = {
+          mason = false,
+          cmd = { vim.fn.expand("~/.rbenv/shims/ruby-lsp") },
+        },
+      },
+    },
+  },
+}

--- a/nvim/lua/config/lsp.lua
+++ b/nvim/lua/config/lsp.lua
@@ -1,0 +1,21 @@
+vim.lsp.enable({
+  'clangd',
+  'lua-language-server',
+  'ruby_lsp',
+})
+
+vim.api.nvim_create_autocmd('LspAttach', {
+  callback = function(ev)
+    local client = vim.lsp.get_client_by_id(ev.data.client_id)
+    if client:supports_method('textDocument/completion') then
+      vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
+    end
+  end,
+})
+
+-- menu: show completion menu
+-- popup: Show extra information about the currently selected
+-- preview: Show extra information about the currently selected
+-- noinsert: Do not insert any text for a match until the user selects
+vim.cmd("set completeopt+=menu,popup,preview,noinsert")
+vim.lsp.completion.enable()

--- a/nvim/lua/plugins/git.lua
+++ b/nvim/lua/plugins/git.lua
@@ -1,0 +1,17 @@
+return {
+  {
+    'tpope/vim-fugitive',
+    lazy = false
+  },
+  { 'airblade/vim-gitgutter', lazy = false },  -- Show git signs on the left
+  {
+    'ruifm/gitlinker.nvim',             -- Copy git link with <leader>gy
+    lazy = false,
+    dependencies = { 'nvim-lua/plenary.nvim' },
+    keys = { },
+    config = function()
+      require('gitlinker').setup {}
+    end,
+  },
+  { 'f-person/git-blame.nvim' }
+}

--- a/nvim/lua/plugins/telescope.lua
+++ b/nvim/lua/plugins/telescope.lua
@@ -37,7 +37,7 @@ return {
           },
         },
         buffers = {
-          theme = "ivy",
+          theme = "dropdown",
           layout_config = {
             width = 0.95, -- Adjust the width (% of the screen)
           },


### PR DESCRIPTION
VIM LSP is only working for clang

- Introduced LSP configurations for clangd, lua-language-server, and ruby_lsp to enhance development experience.
- Updated `init.lua` to include LSP configuration.
- Added new plugins for Git integration: vim-fugitive, vim-gitgutter, gitlinker.nvim, and git-blame.nvim.
- Changed Telescope buffer theme from "ivy" to "dropdown" for better usability.
- Removed unused `gc` alias from `alias.sh`.