### PR TITLE
feat(lsp): add configurations for multiple LSP servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,14 @@ install_lsp_servers:
 	@brew install gopls
 	@echo "  - pyright [Python LSP]"
 	@brew install pyright
-	@echo "  - texlab [LaTeX LSP]"
-	@brew install texlab
-	@echo "  - solargraph [Ruby LSP]"
-	@brew install solargraph
 	@echo "  - ruby-lsp [Ruby LSP]"
 	@brew install ruby-lsp
+	@echo "  - rust-analyzer [Rust LSP]"
+	@brew install rust-analyzer
+	@echo "  - solargraph [Ruby LSP]"
+	@brew install solargraph
+	@echo "  - texlab [LaTeX LSP]"
+	@brew install texlab
 	@echo "  - typescript-language-server [TypeScript LSP]"
 	@brew install typescript-language-server
 

--- a/nvim/lsp/gopls.lua
+++ b/nvim/lsp/gopls.lua
@@ -1,0 +1,5 @@
+return {
+  cmd = { 'gopls' },
+  root_markers = { 'go.mod', '.git' },
+  filetypes = { 'go', 'gomod' },
+}

--- a/nvim/lsp/pyright.lua
+++ b/nvim/lsp/pyright.lua
@@ -1,0 +1,5 @@
+return {
+  cmd = { 'pyright-langserver', '--stdio' },
+  root_markers = { 'pyproject.toml', '.git' },
+  filetypes = { 'python' },
+}

--- a/nvim/lsp/rust_analyzer.lua
+++ b/nvim/lsp/rust_analyzer.lua
@@ -1,0 +1,5 @@
+return {
+  cmd = { 'rust-analyzer' },
+  root_markers = { 'Cargo.toml', '.git' },
+  filetypes = { 'rust' },
+}

--- a/nvim/lsp/solargraph.lua
+++ b/nvim/lsp/solargraph.lua
@@ -1,0 +1,5 @@
+return {
+  cmd = { vim.fn.expand("~/.rbenv/shims/solargraph") },
+  root_markers = { '.ruby-version', '.git' },
+  filetypes = { 'ruby' },
+}

--- a/nvim/lsp/typescript_language_server.lua
+++ b/nvim/lsp/typescript_language_server.lua
@@ -1,0 +1,5 @@
+return {
+  cmd = { 'typescript-language-server', '--stdio' },
+  root_markers = { 'package.json', 'tsconfig.json', '.git' },
+  filetypes = { 'typescript', 'typescriptreact', 'javascript', 'javascriptreact' },
+}


### PR DESCRIPTION
Added configurations for the following LSP servers:
- gopls (Go)
- pyright (Python)
- rust-analyzer (Rust)
- solargraph (Ruby)
- typescript-language-server (TypeScript/JavaScript)

Updated the Makefile to include installation commands for these servers.