### PR TITLE
feat(lsp): add Rubocop and Sorbet configurations

### DIFF
--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -4,6 +4,7 @@
   "blink.cmp": { "branch": "main", "commit": "cb5e346d9e0efa7a3eee7fd4da0b690c48d2a98e" },
   "blossom.vim": { "branch": "main", "commit": "80a34aaa203a6d4f32e2969d616b220426aefb1a" },
   "bufferline.nvim": { "branch": "main", "commit": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3" },
+  "codecompanion.nvim": { "branch": "main", "commit": "dbb85dd371ea7cc945326c88ce45ab8e4677748d" },
   "copilot.vim": { "branch": "release", "commit": "a9228e015528c9307890c48083c925eb98a64a79" },
   "cyberdream.nvim": { "branch": "main", "commit": "c07db2e6cab236ead328afc2ae4e0e1e1c69cd68" },
   "dracula.nvim": { "branch": "main", "commit": "96c9d19ce81b26053055ad6f688277d655b3f7d2" },
@@ -12,6 +13,7 @@
   "gitsigns.nvim": { "branch": "main", "commit": "17ab794b6fce6fce768430ebc925347e349e1d60" },
   "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },
   "lualine.nvim": { "branch": "master", "commit": "482ae358c67aec2a4939d68a1a4fe4c8064ccd16" },
+  "mcphub.nvim": { "branch": "main", "commit": "4fed675f17baa79074c4f0ecdf5b18875f08a179" },
   "molokai": { "branch": "master", "commit": "c67bdfcdb31415aa0ade7f8c003261700a885476" },
   "monokai.nvim": { "branch": "master", "commit": "b8bd44d5796503173627d7a1fc51f77ec3a08a63" },
   "neo-tree.nvim": { "branch": "main", "commit": "73d63376352ac731379892e27ac7b3d9449148e3" },
@@ -35,7 +37,6 @@
   "tokyodark.nvim": { "branch": "master", "commit": "cc70a2fb809d5376f2bd8e5836f9bb3f5fb8ef43" },
   "treesj": { "branch": "main", "commit": "f4049f8ba2177e7c5c03fb9e34d4e039c685d744" },
   "vim-fugitive": { "branch": "master", "commit": "4a745ea72fa93bb15dd077109afbb3d1809383f2" },
-  "vim-gitgutter": { "branch": "main", "commit": "6620e5fbbe6a28de0bfed081f5bd2767023b7eea" },
   "vim-github-colorscheme": { "branch": "master", "commit": "0a660059cae852c7f90951dea7474cfb1485558e" },
   "vim-moonfly-colors": { "branch": "master", "commit": "aee48eb60be3eaa1a58074634534a6d7b3727e5a" }
 }

--- a/nvim/lsp/rubocop.lua
+++ b/nvim/lsp/rubocop.lua
@@ -1,0 +1,8 @@
+--
+-- LSP Configuration for Ruby [rubocop]
+--
+return {
+  cmd = { 'bundle', 'exec', 'rubocop', '--lsp' },
+  root_markers = { 'Gemfile', '.git' },
+  filetypes = { 'ruby' },
+}

--- a/nvim/lsp/sorbet.lua
+++ b/nvim/lsp/sorbet.lua
@@ -1,0 +1,19 @@
+--
+-- LSP Configuration for Sorbet
+--
+return {
+  cmd = { 'bundle', 'exec', 'srb', 'tc', '--lsp' },
+  root_markers = { '.sorbet', 'sorbet/config' },
+  filetypes = { 'ruby' },
+  init_options = {
+    formatting = {
+      format = 'rubocop',
+      rubocop_config = '.rubocop.yml',
+    },
+  },
+  settings = {
+    init_options = {
+      highlightUntyped = true,
+    },
+  },
+}

--- a/nvim/lua/config/lsp.lua
+++ b/nvim/lua/config/lsp.lua
@@ -14,11 +14,13 @@ vim.lsp.enable('dockerls')                          -- Docker language server
 vim.lsp.enable('gopls')                             -- Go language server
 vim.lsp.enable('luals')                             -- LUA LSP server
 vim.lsp.enable('pyright')                           -- Python language server
+vim.lsp.enable('rubocop')                           -- Ruby language server
 vim.lsp.enable('ruby_lsp')                          -- Ruby language server
 vim.lsp.enable('rust_analyzer')                     -- Rust language server
+vim.lsp.enable('sorbet')                            -- Sorbet language server
+vim.lsp.enable('sqlls')                             -- SQL language server
 vim.lsp.enable('texlab')                            -- LaTeX language server
 vim.lsp.enable('tsls')                              -- TypeScript language server
-vim.lsp.enable('sqlls')                             -- SQL language server
 
 
 ------------------------------------------------------------------------------------


### PR DESCRIPTION
- Introduced LSP configuration for Rubocop to support Ruby linting.
- Added Sorbet LSP configuration for type checking and highlighting.
- Updated `lazy-lock.json` to include `codecompanion.nvim` and `mcphub.nvim`.
- Removed `vim-gitgutter` plugin from `lazy-lock.json`.
- Enabled `rubocop` and `sorbet` in `lua/config/lsp.lua`.